### PR TITLE
Remove deprecated APNIC trust anchors

### DIFF
--- a/rp/rcynic/sample-trust-anchors/apnic-rpki-root-afrinic-origin.tal
+++ b/rp/rcynic/sample-trust-anchors/apnic-rpki-root-afrinic-origin.tal
@@ -1,9 +1,0 @@
-rsync://rpki.apnic.net/repository/apnic-rpki-root-afrinic-origin.cer
-
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuMLL96YV9pf0rZ4Ow/bk
-cgpoPfsRzkcgmisyCuMUdotHwrp8pepujhohatScRK09ILRrZYCdpX4121MJhqXC
-P3u3hy9fF0CeARKX/Q82nJccD4dtUp23UcFys8hwJgNYZI910ajkAxwNT//H/TFw
-oUYbzZGBR7o2awMc7GdQl/j6dgOkV6AfYy5DyDEgOUNHnUxED2rreefL/E2Fr2ST
-Esar6bTR4Tg4+nVF1PjAkgN0tKZYe4wZ6VmtqV/VTngSLysim6av7ki+JR3cVgVU
-OqXeh1vPjH2tNu6u9bX37ZrdVb6NBRer9I99IDbKvyhELb6nzo8+Q74zga9HI+Pf
-QwIDAQAB

--- a/rp/rcynic/sample-trust-anchors/apnic-rpki-root-arin-origin.tal
+++ b/rp/rcynic/sample-trust-anchors/apnic-rpki-root-arin-origin.tal
@@ -1,9 +1,0 @@
-rsync://rpki.apnic.net/repository/apnic-rpki-root-arin-origin.cer
-
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp6vscYtzhe0CfFk5Ro44
-llPhsInXtfAxqfYmK7m9V3khkqK3d3/ZAW6pcJm7qW8XhEGl+F5mUeeLIm5JoIhr
-kT5B5M6uL0VlCCkZJH4h76ybOa83vWITNZEDy9L3c3nK4S+Basu3vYoE4ICXGG+J
-7zg5Iw9saV+p03E2w1g16pt1QI3Cnggp6edkeWClEz3aPw/ULOIHb7YmatWwdERl
-tL9LsuMSKszQLUY7F4XVpxey/rJYAZgzDUh+b6813WAClCkkydNjsbviuekAWJbx
-sW7Mcw53u30K4g8MP03CjkDOubyoR4Qo99R1UQJCdrRsFKbSSfN/fOA4y7ikc3xs
-jQIDAQAB

--- a/rp/rcynic/sample-trust-anchors/apnic-rpki-root-lacnic-origin.tal
+++ b/rp/rcynic/sample-trust-anchors/apnic-rpki-root-lacnic-origin.tal
@@ -1,9 +1,0 @@
-rsync://rpki.apnic.net/repository/apnic-rpki-root-lacnic-origin.cer
-
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyoYPp3l3DWyPtLWrmRn4
-Oux9hQ5bxd0SX/f6ygHxik+I3eMJP5J0Pr2e500tyXb2uKsX9kDqu/kckr+TUMhV
-BHd5yAv8OAE3YYEvpz/7uTX7cYy2yUeA76OEP75Y88OIQEzGpPLNpIzDxMggxuDh
-IhkA5xMiUJgVoEgmWSzR+MuRBjv2422wAGB5GpLgYsOjpwvG0VPmhnE+39+10ucQ
-CLt0Ny5kOR4an2tkvHjm7rzKDnFm8MWxPzAWESdf+8g7ITzSglqxDNiK5E5rdzNt
-h1Kvp+9RwaFArw6Ky1A4HhnoplN4EfKwxq0YamuKV0ZTTpWyT2+qDuE6sOfHRbJ0
-5QIDAQAB

--- a/rp/rcynic/sample-trust-anchors/apnic-rpki-root-ripe-origin.tal
+++ b/rp/rcynic/sample-trust-anchors/apnic-rpki-root-ripe-origin.tal
@@ -1,9 +1,0 @@
-rsync://rpki.apnic.net/repository/apnic-rpki-root-ripe-origin.cer
-
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwsQlXmEklLYApoDo7GEa
-NNTEGFPU5wJpi04iXuga2xn+g/TMLOlyJbjuPYRtRm/7VbRnN3m9Ta+WETy03+Fm
-EbXzB4xxhJKVik/ARHBnrBWhLyURy8Q5/XplE9cJein37IE1mIsbKM7o/90S225w
-7GuvW7T4kjPWYmBFOywHWsfQO1EdsgiJrkz+Ab67ZkdSIiKHkf2UE6/MrbDEj+QK
-9+s/vKH8BtDhaLmTWY+bVvfJ3+AWDH6roo1ozbl5yamQFbLOl3ns30f3yOJcNSNu
-/qgMQRRyp2sXXQovhTy8yqm3LFspaCWnTmQtBieWZwibuOa4Z27A1FzTMst2T4wY
-/wIDAQAB


### PR DESCRIPTION
These trust anchors have been deprecated, and will be removed from the APNIC repository at some point in the future (https://www.apnic.net/manage-ip/apnic-services/resource-certification/single-ta-transition).  This PR simply removes them from rpki.net's sample set of TAs (it didn't appear that any other changes were necessary as a result).