### PR TITLE
Add basic support for running a single publication point for an installation

### DIFF
--- a/rp/config/rpki-confgen.xml
+++ b/rp/config/rpki-confgen.xml
@@ -670,6 +670,24 @@
       </doc>
     </option>
 
+    <option name  = "publication_point_single_entity"
+            value = "">
+       <doc>
+         When operating a local parent engine under a remote parent
+         that offers publication protocol service, it's not possible
+         by default to have the local parent engine publish to the
+         remote parent on behalf of its child engines.  However, this
+         can be handled by setting up a dummy engine for publication,
+         and having that dummy engine publish all local repository
+         objects to the remote parent's publication point.  If the
+         entity and repository handle configuration settings below are
+         set to non-empty values, then that entity will periodically
+         publish all local objects to the configured repository.
+       </doc>
+    </option>
+    <option name  = "publication_point_single_repository_handle"
+            value = "" />
+
   </section>
 
   <section name = "irdbd">


### PR DESCRIPTION
When operating a local parent engine under a remote parent that offers
publication protocol service, it's not possible by default to have the
local parent engine publish to the remote parent on behalf of its
child engines.  However, this can be handled by setting up a dummy
engine for publication, and having that dummy engine publish all local
repository objects to the remote parent's publication point, using a
new task for that purpose.

Feedback on this approach would be much appreciated: it's a bit of a
hack, and it's likely that there are cleaner ways to do it.  I'll fix
cut-and-paste, add tests and documentation, etc. once that's resolved
(assuming that modifying this codebase is the right way to handle this
use case).

Test details:

    # {pp-parent}, {pp-child}, and {pp-pub} are three placeholders used as
    # entity identifiers through these tests.  Any string that's not currently in
    # use as a handle in the APNIC testbed can be used for {pp-parent}, and
    # any (distinct) strings can be used for {pp-child} and {pp-pub}.  To find the
    # handles that are currently in use:
    $ rsync -Laz rsync://rpki-testbed.apnic.net/repository testbed
    $ for i in `find testbed -iname '*.cer'`; do openssl x509 -inform DER -in $i -text -noout | grep 'Subject: CN='; done | sed 's/.*Subject: CN=//' | sed 's/\/.*//' | sort | uniq

    $ docker run -ti -p8443:443 apnic/rpki.net

    # Copy new rpkid_tasks.py to container:/usr/lib/python2.7/dist-packages/rpki/rpkid_tasks.py.
    # Under [rpkid] in /etc/rpki.conf, add:
    #   publication_point_single_entity = {pp-pub}
    #   publication_point_single_repository_handle = {pp-parent}
    # Under [myrpki] in /etc/rpki.conf, set:
    #   publication_rrdp_base_uri = https://rpki-testbed.apnic.net:7788/rrdp/
    #   publication_rrdp_notification_uri = ${myrpki::publication_rrdp_base_uri}notification.xml
    $ /etc/init.d/rpki-ca restart

    # Create the local parent engine.
    $ rpkic create_identity {pp-parent}
    Wrote /{pp-parent}.identity.xml
    This is the "identity" file you will need to send to your parent

    # Register the identity file at https://rpki-testbed.apnic.net,
    # with resource holdings of 10/8. Save the response to
    # {pp-parent}.parent-response.xml.
    $ rpkic -i {pp-parent} configure_parent {pp-parent}.parent-response.xml
    Parent calls itself 'APNIC-AP', we call it 'APNIC-AP'
    Parent calls us '{pp-parent}'
    Wrote /{pp-parent}.APNIC-AP.repository-request.xml
    This is the file to send to the repository operator

    # Create the dummy publication engine and link it (up-down) to
    # the local parent.
    $ rpkic create_identity {pp-pub}
    Wrote /{pp-pub}.identity.xml
    This is the "identity" file you will need to send to your parent
    $ rpkic -i {pp-parent} configure_child {pp-pub}.identity.xml
    Child calls itself '{pp-pub}', we call it '{pp-pub}'
    Couldn't find any usable repositories, not giving referral
    Wrote /{pp-parent}.{pp-pub}.parent-response.xml
    Send this file back to the child you just configured
    $ rpkic -i {pp-pub} configure_parent {pp-parent}.{pp-pub}.parent-response.xml
    Parent calls itself '{pp-parent}', we call it '{pp-parent}'
    Parent calls us '{pp-pub}'
    Wrote /{pp-pub}.{pp-parent}.repository-request.xml
    This is the file to send to the repository operator

    # Register the publication repository request at
    # https://rpki-testbed.apnic.net, using {pp-parent} as the handle.
    # Save the response to {pp-pub}.repository-response.xml.
    $ rpkic -i {pp-pub} configure_repository {pp-pub}.repository-response.xml
    Repository calls us '{pp-parent}'
    No explicit parent_handle given, guessing parent {pp-parent}

    # Configure the publication client for the local parent,
    # overriding the SIA so that it points to the publication URL.
    # The SIA can be found in {pp-pub}.repository-response.xml.
    $ rpkic -i {pp-parent} configure_publication_client {pp-parent}.APNIC-AP.repository-request.xml --sia_base rsync://rpki-testbed.apnic.net/external_repository/{pp-parent}/
    Client calls itself '{pp-parent}', we call it '{pp-parent}'
    Wrote /{pp-parent}.repository-response.xml
    Send this file back to the publication client you just configured
    $ rpkic -i {pp-parent} configure_repository {pp-parent}.repository-response.xml
    Repository calls us '{pp-parent}'
    No explicit parent_handle given, guessing parent APNIC-AP

    # Run tasks for the local parent and the publication engine, and
    # confirm that the local objects are published remotely.  (It may
    # be a couple of minutes after publishing before it appears
    # remotely.)
    $ rpkic -i {pp-parent} force_run_now
    $ rpkic -i {pp-pub} force_run_now
    $ rsync -r rsync://rpki-testbed.apnic.net/external_repository/{pp-parent}
    ...

    # Create a local child engine, add a ROA, and confirm that it is
    # published remotely.  (As before, it may be a couple of minutes
    # after publishing before it appears remotely.)
    $ rpkic create_identity {pp-child}
    Wrote /{pp-child}.identity.xml
    This is the "identity" file you will need to send to your parent
    $ rpkic -i {pp-parent} configure_child {pp-child}.identity.xml
    Child calls itself '{pp-child}', we call it '{pp-child}'
    Wrote /{pp-parent}.{pp-child}.parent-response.xml
    Send this file back to the child you just configured
    $ rpkic -i {pp-child} configure_parent {pp-parent}.{pp-child}.parent-response.xml
    Parent calls itself '{pp-parent}', we call it '{pp-parent}'
    Parent calls us '{pp-child}'
    Wrote /{pp-child}.{pp-parent}.repository-request.xml
    This is the file to send to the repository operator
    $ rpkic -i {pp-parent} configure_publication_client {pp-child}.{pp-parent}.repository-request.xml
    This looks like a referral, checking
    Client calls itself '{pp-child}', we call it '{pp-parent}/{pp-child}'
    Wrote /{pp-parent}.{pp-child}.repository-response.xml
    Send this file back to the publication client you just configured
    $ rpkic -i {pp-child} configure_repository {pp-parent}.{pp-child}.repository-response.xml
    Repository calls us '{pp-parent}/{pp-child}'
    No explicit parent_handle given, guessing parent {pp-parent}
    $ echo "{pp-child}^I10.0.0.0/16" > prefixes.csv
    $ rpkic -i {pp-parent} load_prefixes prefixes.csv
    $ echo "10.0.0.0/16-16^I1234567" > roas.csv
    $ rpkic -i {pp-child} load_roa_requests roas.csv
    $ rpkic -i {pp-child} force_run_now
    $ rpkic -i {pp-pub} force_run_now
    $ rsync -r rsync://rpki-testbed.apnic.net/external_repository/{pp-parent}
    ...
